### PR TITLE
Add GPU Support

### DIFF
--- a/afsl/acquisition_functions/cosine_similarity.py
+++ b/afsl/acquisition_functions/cosine_similarity.py
@@ -70,13 +70,14 @@ class CosineSimilarity(
         self,
         model: ModelWithEmbedding | None,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
         data_latent = self.compute_embedding(
             model=model, data=data, batch_size=self.embedding_batch_size
-        )
+        ).to(device)
         target_latent = self.compute_embedding(
             model=model, data=self.get_target(), batch_size=self.embedding_batch_size
-        )
+        ).to(device)
 
         data_latent_normalized = F.normalize(data_latent, p=2, dim=1)
         target_latent_normalized = F.normalize(target_latent, p=2, dim=1)

--- a/afsl/acquisition_functions/information_density.py
+++ b/afsl/acquisition_functions/information_density.py
@@ -64,7 +64,8 @@ class InformationDensity(BatchAcquisitionFunction):
         self,
         model: ModelWithEmbedding,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
-        entropy = self.max_entropy.compute(model, data)
-        cosine_similarity = self.cosine_similarity.compute(model, data)
+        entropy = self.max_entropy.compute(model, data, device)
+        cosine_similarity = self.cosine_similarity.compute(model, data, device)
         return entropy * cosine_similarity**self.beta

--- a/afsl/acquisition_functions/least_confidence.py
+++ b/afsl/acquisition_functions/least_confidence.py
@@ -21,6 +21,7 @@ class LeastConfidence(BatchAcquisitionFunction):
         self,
         model: Model,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
         model.eval()
         with torch.no_grad():
@@ -28,7 +29,7 @@ class LeastConfidence(BatchAcquisitionFunction):
             def engine(batch: torch.Tensor) -> torch.Tensor:
                 output = torch.softmax(
                     model(batch.to(get_device(model), non_blocking=True)), dim=1
-                )
+                ).to(device)
                 return -torch.max(output, dim=1).values
 
             return mini_batch_wrapper(

--- a/afsl/acquisition_functions/max_entropy.py
+++ b/afsl/acquisition_functions/max_entropy.py
@@ -22,6 +22,7 @@ class MaxEntropy(BatchAcquisitionFunction):
         self,
         model: Model,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
         model.eval()
         with torch.no_grad():
@@ -29,7 +30,7 @@ class MaxEntropy(BatchAcquisitionFunction):
             def engine(batch: torch.Tensor) -> torch.Tensor:
                 output = torch.softmax(
                     model(batch.to(get_device(model), non_blocking=True)), dim=1
-                )
+                ).to(device)
                 entropy = -torch.sum(output * torch.log(output), dim=1)
                 return entropy
 

--- a/afsl/acquisition_functions/min_margin.py
+++ b/afsl/acquisition_functions/min_margin.py
@@ -22,6 +22,7 @@ class MinMargin(BatchAcquisitionFunction):
         self,
         model: Model,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
         model.eval()
         with torch.no_grad():
@@ -29,7 +30,7 @@ class MinMargin(BatchAcquisitionFunction):
             def engine(batch: torch.Tensor) -> torch.Tensor:
                 output = torch.softmax(
                     model(batch.to(get_device(model), non_blocking=True)), dim=1
-                )
+                ).to(device)
                 top_preds, _ = torch.topk(output, 2, dim=1)
                 margins = top_preds[:, 0] - top_preds[:, 1]
                 return -margins

--- a/afsl/acquisition_functions/random.py
+++ b/afsl/acquisition_functions/random.py
@@ -36,5 +36,6 @@ class Random(BatchAcquisitionFunction):
         self,
         model: Model,
         data: torch.Tensor,
+        device: torch.device | None = None,
     ) -> torch.Tensor:
-        return torch.randperm(data.size(0))
+        return torch.randperm(data.size(0), device=device)

--- a/afsl/acquisition_functions/undirected_vtl.py
+++ b/afsl/acquisition_functions/undirected_vtl.py
@@ -3,7 +3,12 @@ import wandb
 from afsl.acquisition_functions.bace import BaCEState, TargetedBaCE
 from afsl.acquisition_functions.vtl import VTL
 from afsl.gaussian import get_jitter
-from afsl.utils import DEFAULT_MINI_BATCH_SIZE, DEFAULT_NUM_WORKERS, DEFAULT_SUBSAMPLE
+from afsl.utils import (
+    DEFAULT_EMBEDDING_BATCH_SIZE,
+    DEFAULT_MINI_BATCH_SIZE,
+    DEFAULT_NUM_WORKERS,
+    DEFAULT_SUBSAMPLE,
+)
 
 
 class UndirectedVTL(VTL):
@@ -26,6 +31,7 @@ class UndirectedVTL(VTL):
         self,
         noise_std=1.0,
         mini_batch_size=DEFAULT_MINI_BATCH_SIZE,
+        embedding_batch_size=DEFAULT_EMBEDDING_BATCH_SIZE,
         num_workers=DEFAULT_NUM_WORKERS,
         subsample=DEFAULT_SUBSAMPLE,
         force_nonsequential=False,
@@ -33,6 +39,7 @@ class UndirectedVTL(VTL):
         """
         :param noise_std: Standard deviation of the noise.
         :param mini_batch_size: Size of mini-batch used for computing the acquisition function.
+        :param embedding_batch_size: Batch size used for computing the embeddings.
         :param force_nonsequential: Whether to force non-sequential data selection.
         """
         TargetedBaCE.__init__(
@@ -40,6 +47,7 @@ class UndirectedVTL(VTL):
             target=torch.tensor([]),
             noise_std=noise_std,
             mini_batch_size=mini_batch_size,
+            embedding_batch_size=embedding_batch_size,
             num_workers=num_workers,
             subsample=subsample,
             force_nonsequential=force_nonsequential,


### PR DESCRIPTION
Adds a `device` argument to the `Retriever` that interoperates with FAISS. This argument determines where the computation of the acquisition function happens.