### PR TITLE
also query opposite by default

### DIFF
--- a/activeft/sift.py
+++ b/activeft/sift.py
@@ -55,7 +55,7 @@ class Retriever:
         acquisition_function: AcquisitionFunction | None = None,
         llambda: float = 0.01,
         fast: bool = False,
-        also_query_opposite: bool = False,
+        also_query_opposite: bool = True,
         only_faiss: bool = False,
         device: torch.device | None = None,
     ):


### PR DESCRIPTION
Use absolute inner product search for Faiss pre-selection in SIFT by default.
Previously, normal inner product search was used.